### PR TITLE
[2767] Fix token method imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Mercado Pago's Official React SDK.
     - [Expiration Date](#expiration-date)
     - [Expiration Month](#expiration-month)
     - [Expiration Year](#expiration-year)
-  - [Core Methods](#core-methods)
     - [createCardToken](#createcardtoken)
     - [updateCardToken](#updatecardtoken)
+  - [Core Methods](#core-methods)
     - [getIdentificationTypes](#getidentificationtypes)
     - [getPaymentMethods](#getpaymentmethods)
     - [getIssuers](#getissuers)
@@ -178,7 +178,9 @@ The Secure Fields module also provides a method to get the card token safely wit
 > **Note**
 > It's mandatory to have previously done the [Initialization step](#initialization)
 
-### Card Number
+### Components
+
+#### Card Number
 
 ```jsx
 import { CardNumber } from '@mercadopago/sdk-react';
@@ -191,7 +193,7 @@ export default App;
 
 <br/>
 
-### Security Code
+#### Security Code
 
 ```jsx
 import { SecurityCode } from '@mercadopago/sdk-react';
@@ -204,7 +206,7 @@ export default App;
 
 <br/>
 
-### Expiration Date
+#### Expiration Date
 
 > Note: Expiration Date cannot coexist with Expiration Month or Expiration Year
 
@@ -219,7 +221,7 @@ export default App;
 
 <br/>
 
-### Expiration Month
+#### Expiration Month
 
 ```jsx
 import { ExpirationMonth } from '@mercadopago/sdk-react';
@@ -232,7 +234,7 @@ export default App;
 
 <br/>
 
-### Expiration Year
+#### Expiration Year
 
 ```jsx
 import { ExpirationYear } from '@mercadopago/sdk-react';
@@ -245,14 +247,9 @@ export default App;
 
 <br/>
 
-## Core Methods
+### Methods
 
-For a full explanation of each function parameters and return, check the [SDK-JS documentation of the Core Methods](https://github.com/mercadopago/sdk-js/blob/main/docs/core-methods.md)
-
-> **Note**
-> It's mandatory to have previously done the [Initialization step](#initialization)
-
-### createCardToken
+#### createCardToken
 
 Return a token card
 
@@ -265,7 +262,7 @@ const cardToken = await createCardToken({
 });
 ```
 
-### updateCardToken
+#### updateCardToken
 
 Update a token card
 
@@ -273,6 +270,13 @@ Update a token card
 import { updateCardToken } from '@mercadopago/sdk-react';
 const cardToken = await updateCardToken('<OLD_CARD_TOKEN>');
 ```
+
+## Core Methods
+
+For a full explanation of each function parameters and return, check the [SDK-JS documentation of the Core Methods](https://github.com/mercadopago/sdk-js/blob/main/docs/core-methods.md)
+
+> **Note**
+> It's mandatory to have previously done the [Initialization step](#initialization)
 
 ### getIdentificationTypes
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Mercado Pago's Official React SDK.
     - [Expiration Date](#expiration-date)
     - [Expiration Month](#expiration-month)
     - [Expiration Year](#expiration-year)
-    - [createCardToken](#createcardtoken)
   - [Core Methods](#core-methods)
+    - [createCardToken](#createcardtoken)
+    - [updateCardToken](#updatecardtoken)
     - [getIdentificationTypes](#getidentificationtypes)
     - [getPaymentMethods](#getpaymentmethods)
     - [getIssuers](#getissuers)
     - [getInstallments](#getinstallments)
-    - [createCardToken](#createcardtoken-1)
   - [Run SDK project](#run-sdk-project)
   - [License](#license)
 
@@ -245,6 +245,13 @@ export default App;
 
 <br/>
 
+## Core Methods
+
+For a full explanation of each function parameters and return, check the [SDK-JS documentation of the Core Methods](https://github.com/mercadopago/sdk-js/blob/main/docs/core-methods.md)
+
+> **Note**
+> It's mandatory to have previously done the [Initialization step](#initialization)
+
 ### createCardToken
 
 Return a token card
@@ -258,14 +265,14 @@ const cardToken = await createCardToken({
 });
 ```
 
-<br/>
+### updateCardToken
 
-## Core Methods
+Update a token card
 
-For a full explanation of each function parameters and return, check the [SDK-JS documentation of the Core Methods](https://github.com/mercadopago/sdk-js/blob/main/docs/core-methods.md)
-
-> **Note**
-> It's mandatory to have previously done the [Initialization step](#initialization)
+```javascript
+import { updateCardToken } from '@mercadopago/sdk-react';
+const cardToken = await updateCardToken('<OLD_CARD_TOKEN>');
+```
 
 ### getIdentificationTypes
 
@@ -310,24 +317,7 @@ const installments = await getInstallments({
 });
 ```
 
-### createCardToken
-
-Return a token card
-
-```javascript
-import { createCardToken } from '@mercadopago/sdk-react/esm/coreMethods';
-const cardToken = await createCardToken({
-  cardNumber: '<CREDIT_CARD_NUMBER>',
-  cardholderName: '<CARDHOLDER_NAME>',
-  cardExpirationMonth: '<CARD_EXPIRATION_MONTH>',
-  cardExpirationYear: '<CARD_EXPIRATION_YEAR>',
-  securityCode: '<CARD_SECURITY_CODE>',
-  identificationType: '<BUYER_IDENTIFICATION_TYPE>',
-  identificationNumber: '<BUYER_IDENTIFICATION_NUMBER>',
-});
-```
-
-> When importing directly from `/coreMethods`, you have to explicitly choose between the `/esm` or `/cjs` export formats. For example, use `import { createCardToken } from '@mercadopago/sdk-react/esm/coreMethods';` for ECMAScript modules, or `const { createCardToken } = require('@mercadopago/sdk-react/cjs/coreMethods');` for CommonJS modules. For root imports, this selection is not necessary.
+> By default, your bundler should select the appropriate module format. However, if you need to explicitly use ECMAScript Modules (ESM) or CommonJS (CJS), you can specify. For example, use `import createCardToken from '@mercadopago/sdk-react/esm/secureFields/createCardToken/index';` for ECMAScript modules, or `const createCardToken = require('@mercadopago/sdk-react/cjs/secureFields/createCardToken/index');` for CommonJS modules.
 
 ## Run SDK project
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mercadopago/sdk-react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mercadopago/sdk-react",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@mercadopago/sdk-js": "^0.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercadopago/sdk-react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Mercado Pago SDK React",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/coreMethods/index.ts
+++ b/src/coreMethods/index.ts
@@ -1,0 +1,4 @@
+import createCardToken from './cardToken/create';
+import updateCardToken from './cardToken/update';
+
+export { createCardToken, updateCardToken };


### PR DESCRIPTION
## Description 

[2767] | Removing documentation for non Secure Fields token manipulation. 

* Added file `src/coreMethods/index.ts` so edge case users can import it directly
* Updated README to reference only Secure Fields implementation
* Documented `updateCardToken` method